### PR TITLE
feat: Add a reboot dialog to the "Apply" button

### DIFF
--- a/src/umupgrader.nim
+++ b/src/umupgrader.nim
@@ -151,7 +151,19 @@ method view(app: AppState): Widget =
               style = [ButtonSuggested]
 
             proc clicked() =
-              app.hub[].toThrd.send fmt "reboot\n{app.user.name}\n{app.user.password}"
+              let (res, _) = app.open: gui:
+                MessageDialog:
+                  message = "Your computer needs to be restarted for a system upgrade."
+                  DialogButton {.addButton.}:
+                      text = "Cancel"
+                      res = DialogCancel
+                  DialogButton {.addButton.}:
+                      text = "Restart"
+                      res = DialogAccept
+                      style = [ButtonDestructive]
+
+              if res.kind == DialogAccept:
+                app.hub[].toThrd.send fmt "reboot\n{app.user.name}\n{app.user.password}"
 
         ScrolledWindow:
           TextView:


### PR DESCRIPTION
This PR adds a reboot dialog to the 'Apply' button in the app to make sure that everybody who does this action is aware of it and that it cannot be done by accident.