### PR TITLE
fix: Change Apply button text to be less urgent

### DIFF
--- a/src/umupgrader.nim
+++ b/src/umupgrader.nim
@@ -145,7 +145,7 @@ method view(app: AppState): Widget =
               app.hub[].toThrd.send fmt "download\n{app.user.name}\n{app.user.password}\n{ver}"
 
           Button:
-            text = "Apply Update (Reboot RIGHT NOW)"
+            text = "Apply Update (Requires Reboot)"
             sensitive = app.canApplyUpdate
             if app.canApplyUpdate:
               style = [ButtonSuggested]


### PR DESCRIPTION
Change the wording of the "Apply" button to be less forceful and more informative, since the action is not that destructive and can give the user an unneeded sense of emergency.